### PR TITLE
Fix segfaults when running on Linux

### DIFF
--- a/src/whisper-utils/token-buffer-thread.cpp
+++ b/src/whisper-utils/token-buffer-thread.cpp
@@ -96,9 +96,13 @@ void TokenBufferThread::monitor()
 		// emit the caption from the tokens
 		std::string output;
 		for (const auto &token : emitted) {
-			const char *token_str =
-				whisper_token_to_str(this->gf->whisper_context, token.id);
-			output += token_str;
+			try {
+				const char *token_str =
+					whisper_token_to_str(this->gf->whisper_context, token.id);
+				output += token_str;
+			} catch (std::out_of_range) {
+				obs_log(LOG_WARNING, "TokenBufferThread::monitor: word not found in whisper context for token ID %d", token.id);
+			}
 		}
 		this->callback(output);
 		// push back the words that were emitted, in reverse order

--- a/src/whisper-utils/token-buffer-thread.cpp
+++ b/src/whisper-utils/token-buffer-thread.cpp
@@ -109,14 +109,10 @@ void TokenBufferThread::monitor()
 		// check if we need to flush the queue
 		auto elapsedTime = std::chrono::duration_cast<std::chrono::seconds>(
 			std::chrono::steady_clock::now() - startTime);
-		if (this->wordQueue.size() >= this->maxSize || elapsedTime >= this->maxTime) {
-			// flush the queue if it's full or we've reached the max time
-			size_t words_to_flush = std::min(this->wordQueue.size(), this->maxSize);
+		if ((this->wordQueue.size() >= this->maxSize) || (elapsedTime >= this->maxTime && this->wordQueue.size() > 3)) {
+			// flush the queue if it's full or if we've reached the max time
 			// make sure we leave at least 3 words in the queue
-			size_t words_remaining = this->wordQueue.size() - words_to_flush;
-			if (words_remaining < 3) {
-				words_to_flush -= 3 - words_remaining;
-			}
+			size_t words_to_flush = std::min(this->wordQueue.size() - 3, this->maxSize);
 			obs_log(LOG_INFO, "TokenBufferThread::monitor: flushing %d words",
 				words_to_flush);
 			for (size_t i = 0; i < words_to_flush; ++i) {


### PR DESCRIPTION
I found a couple of places where I was getting segmentation faults, so I fixed them :)

* When using buffered output, sometimes it tried to remove more items from the queue than the number of items in the queue
* A segfault sometimes occurred when doing processing on the text before updating the caption outputs if the string was empty, so now all processing that is irrelevant for empty strings is skipped