### PR TITLE
refactor: Update model-downloader.cpp to use obs_module_config_path f…

### DIFF
--- a/src/model-utils/model-downloader-ui.cpp
+++ b/src/model-utils/model-downloader-ui.cpp
@@ -125,10 +125,22 @@ std::string get_filename_from_url(const std::string &url)
 
 void ModelDownloadWorker::download_model()
 {
-	char *config_folder = obs_module_get_config_path(obs_current_module(), "models");
-	const std::filesystem::path module_config_models_folder =
-		std::filesystem::absolute(config_folder);
+	char *config_folder = obs_module_config_path("models");
+#ifdef _WIN32
+	// convert mbstring to wstring
+	int count = MultiByteToWideChar(CP_UTF8, 0, config_folder, strlen(config_folder), NULL, 0);
+	std::wstring config_folder_str(count, 0);
+	MultiByteToWideChar(CP_UTF8, 0, config_folder, strlen(config_folder), &config_folder_str[0],
+			    count);
+	obs_log(LOG_INFO, "Download: Config models folder: %S", config_folder_str.c_str());
+#else
+	std::string config_folder_str = config_folder;
+	obs_log(LOG_INFO, "Download: Config models folder: %s", config_folder_str.c_str());
+#endif
 	bfree(config_folder);
+
+	const std::filesystem::path module_config_models_folder =
+		std::filesystem::absolute(config_folder_str);
 
 	// Check if the config folder exists
 	if (!std::filesystem::exists(module_config_models_folder)) {

--- a/src/model-utils/model-downloader.cpp
+++ b/src/model-utils/model-downloader.cpp
@@ -27,9 +27,25 @@ std::string find_model_folder(const ModelInfo &model_info)
 	}
 
 	// Check if model exists in the config folder
-	char *config_folder = obs_module_get_config_path(obs_current_module(), "models");
+	char *config_folder = obs_module_config_path("models");
+	if (!config_folder) {
+		obs_log(LOG_INFO, "Config folder not set.");
+		return "";
+	}
+#ifdef _WIN32
+	// convert mbstring to wstring
+	int count = MultiByteToWideChar(CP_UTF8, 0, config_folder, strlen(config_folder), NULL, 0);
+	std::wstring config_folder_str(count, 0);
+	MultiByteToWideChar(CP_UTF8, 0, config_folder, strlen(config_folder), &config_folder_str[0],
+			    count);
+	obs_log(LOG_INFO, "Config models folder: %S", config_folder_str.c_str());
+#else
+	std::string config_folder_str = config_folder;
+	obs_log(LOG_INFO, "Config models folder: %s", config_folder_str.c_str());
+#endif
+
 	const std::filesystem::path module_config_models_folder =
-		std::filesystem::absolute(config_folder);
+		std::filesystem::absolute(config_folder_str);
 	bfree(config_folder);
 
 	obs_log(LOG_INFO, "Checking if model '%s' exists in config...",
@@ -38,9 +54,9 @@ std::string find_model_folder(const ModelInfo &model_info)
 	const std::string model_local_config_path =
 		(module_config_models_folder / model_info.local_folder_name).string();
 
-	obs_log(LOG_INFO, "Model path in config: %s", model_local_config_path.c_str());
+	obs_log(LOG_INFO, "Lookig for model in config: %s", model_local_config_path.c_str());
 	if (std::filesystem::exists(model_local_config_path)) {
-		obs_log(LOG_INFO, "Model exists in config folder: %s",
+		obs_log(LOG_INFO, "Model folder exists in config folder: %s",
 			model_local_config_path.c_str());
 		return model_local_config_path;
 	}

--- a/src/transcription-filter-data.h
+++ b/src/transcription-filter-data.h
@@ -38,6 +38,7 @@ struct transcription_filter_data {
 	size_t min_sub_duration;
 	// Last time a subtitle was rendered
 	uint64_t last_sub_render_time;
+	bool cleared_last_sub;
 
 	/* PCM buffers */
 	float *copy_buffers[MAX_PREPROC_CHANNELS];

--- a/src/transcription-filter.cpp
+++ b/src/transcription-filter.cpp
@@ -186,7 +186,7 @@ void transcription_filter_update(void *data, obs_data_t *s)
 	gf->sentence_number = 1;
 	gf->process_while_muted = obs_data_get_bool(s, "process_while_muted");
 	gf->min_sub_duration = (int)obs_data_get_int(s, "min_sub_duration");
-	gf->last_sub_render_time = 0;
+	gf->last_sub_render_time = now_ms();
 	bool new_buffered_output = obs_data_get_bool(s, "buffered_output");
 	int new_buffer_num_lines = (int)obs_data_get_int(s, "buffer_num_lines");
 	int new_buffer_num_chars_per_line = (int)obs_data_get_int(s, "buffer_num_chars_per_line");
@@ -428,7 +428,7 @@ void *transcription_filter_create(obs_data_t *settings, obs_source_t *filter)
 	gf->frames = (size_t)((float)gf->sample_rate / (1000.0f / MAX_MS_WORK_BUFFER));
 	gf->last_num_frames = 0;
 	gf->min_sub_duration = (int)obs_data_get_int(settings, "min_sub_duration");
-	gf->last_sub_render_time = 0;
+	gf->last_sub_render_time = now_ms();
 	gf->log_level = (int)obs_data_get_int(settings, "log_level");
 	gf->save_srt = obs_data_get_bool(settings, "subtitle_save_srt");
 	gf->truncate_output_file = obs_data_get_bool(settings, "truncate_output_file");


### PR DESCRIPTION
…or retrieving the config folder path

- Replace the usage of obs_module_get_config_path with obs_module_config_path to retrieve the config folder path in model-downloader.cpp
- Add a check for a null config_folder and log an info message if it is null
- Convert the config_folder string to a wstring on Windows using MultiByteToWideChar
- Update the log messages to provide more descriptive information about the config models folder and the model folder existence in the config folder
- Use the updated config_folder_str in the std::filesystem::absolute function call